### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,8 @@
 name: tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/99071673/LunchPicker/security/code-scanning/1](https://github.com/99071673/LunchPicker/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Based on the actions performed in the workflow, the minimal permissions required are `contents: read`. This ensures that the `GITHUB_TOKEN` has only the necessary access to the repository contents and avoids granting unnecessary write permissions.

The `permissions` block can be added at the root level of the workflow file to apply to all jobs, or it can be added specifically to the `ci` job. In this case, adding it at the root level is sufficient and simplifies the configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
